### PR TITLE
Restyle info row to be inline

### DIFF
--- a/rarbg-helper.user.js
+++ b/rarbg-helper.user.js
@@ -43,6 +43,7 @@
 // @match                 *://rarbgunblock.com/*
 // @connect               *
 // @supportURL            https://github.com/PeratX/RARBGHelper
+// @updateURL             https://raw.githubusercontent.com/PeratX/RARBGHelper/master/helper.js
 // @grant                 GM_xmlhttpRequest
 // ==/UserScript==
 

--- a/rarbg-helper.user.js
+++ b/rarbg-helper.user.js
@@ -53,6 +53,7 @@
     const githubStar = '<iframe src="https://ghbtns.com/github-btn.html?user=PeratX&repo=RARBGHelper&type=star&count=true" frameborder="0" scrolling="0" style="height: 20px;max-width: 120px;padding: 0 5px;box-sizing: border-box;margin-top: 5px;"></iframe>';
     const magnetImg  = '<img src="https://dyncdn2.com/static/20/img/magnet.gif"        style="height: 12px; width: 12px; margin-bottom:-2px;" border="0">';
     const downloadImg = '<img src="https://dyncdn.me/static/20/img/16x16/download.png" style="height: 12px; width: 12px; margin-bottom:-2px;" border="0" "="">';
+    const starEmoji   = '&#x2B50';
 
     function getStringBetween(str, begin, end) {
         if (str.indexOf(begin) >= 0) {
@@ -82,7 +83,7 @@
                 fetch(page).then(body => body.text()).then(b => {
                     let parser = new DOMParser().parseFromString(b, "text/html");
                     let dl = parser.querySelector("td.lista a[id]");
-                    a.parentNode.innerHTML += "<span>Rating: " + parser.querySelector("li.current-rating").innerHTML.replace("Currently ", "").trim().replace(/(\d\.\d)\d/, "$1") + "     </span>" +
+                    a.parentNode.innerHTML += "<span>" + starEmoji +": " + parser.querySelector("li.current-rating").innerHTML.replace("Currently ", "").trim().replace(/(\d\.\d)\d/, "$1") + "     </span>" +
                         '<a href="' + dl.getAttribute("href") + '">' + downloadImg + '</a><span>     </span><a href="' + dl.nextElementSibling.getAttribute("href") + '">' + magnetImg + '</a>';
                 })
             }

--- a/rarbg-helper.user.js
+++ b/rarbg-helper.user.js
@@ -43,7 +43,6 @@
 // @match                 *://rarbgunblock.com/*
 // @connect               *
 // @supportURL            https://github.com/PeratX/RARBGHelper
-// @updateURL             https://raw.githubusercontent.com/PeratX/RARBGHelper/master/helper.js
 // @grant                 GM_xmlhttpRequest
 // ==/UserScript==
 
@@ -51,6 +50,8 @@
     'use strict';
 
     const githubStar = '<iframe src="https://ghbtns.com/github-btn.html?user=PeratX&repo=RARBGHelper&type=star&count=true" frameborder="0" scrolling="0" style="height: 20px;max-width: 120px;padding: 0 5px;box-sizing: border-box;margin-top: 5px;"></iframe>';
+    const magnetImg  = '<img src="https://dyncdn2.com/static/20/img/magnet.gif" border="0">';
+    const downloadImg = '<img src="https://dyncdn.me/static/20/img/16x16/download.png" style="height: 12px; width: 12px;" border="0" "="">';
 
     function getStringBetween(str, begin, end) {
         if (str.indexOf(begin) >= 0) {
@@ -80,8 +81,8 @@
                 fetch(page).then(body => body.text()).then(b => {
                     let parser = new DOMParser().parseFromString(b, "text/html");
                     let dl = parser.querySelector("td.lista a[id]");
-                    a.parentNode.innerHTML += "<span>Rating: " + parser.querySelector("li.current-rating").innerHTML.replace("Currently ", "").trim() + "     </span>" +
-                        '<a href="' + dl.getAttribute("href") + '">Download Torrent</a><span>     </span><a href="' + dl.nextElementSibling.getAttribute("href") + '">Magnet</a>';
+                    a.parentNode.innerHTML += "<span>Rating: " + parser.querySelector("li.current-rating").innerHTML.replace("Currently ", "").trim().replace(/(\d\.\d)\d/, "$1") + "     </span>" +
+                        '<a href="' + dl.getAttribute("href") + '">' + downloadImg + '</a><span>     </span><a href="' + dl.nextElementSibling.getAttribute("href") + '">' + magnetImg + '</a>';
                 })
             }
         }
@@ -103,7 +104,7 @@
 
         let td = document.querySelectorAll('tr[class="lista2"] > td:nth-child(2)')
         for (let i = 0; i < td.length; i++) {
-            td[i].innerHTML += '<br><a href="https://github.com/PeratX/RARBGHelper" target="_blank"><img src="https://github.githubassets.com/favicon.ico" border="0" style="width: 12px;"></a><span>     </span>'
+            td[i].innerHTML += '<a href="https://github.com/PeratX/RARBGHelper" target="_blank"><img src="https://github.githubassets.com/favicon.ico" border="0" style="width: 12px;"></a><span>     </span>'
         }
         let a = document.querySelectorAll('tr[class="lista2"] > td:nth-child(2) >a:nth-child(1)')
         for (let i = 0; i < a.length; i++) {

--- a/rarbg-helper.user.js
+++ b/rarbg-helper.user.js
@@ -51,8 +51,8 @@
     'use strict';
 
     const githubStar = '<iframe src="https://ghbtns.com/github-btn.html?user=PeratX&repo=RARBGHelper&type=star&count=true" frameborder="0" scrolling="0" style="height: 20px;max-width: 120px;padding: 0 5px;box-sizing: border-box;margin-top: 5px;"></iframe>';
-    const magnetImg  = '<img src="https://dyncdn2.com/static/20/img/magnet.gif" border="0">';
-    const downloadImg = '<img src="https://dyncdn.me/static/20/img/16x16/download.png" style="height: 12px; width: 12px;" border="0" "="">';
+    const magnetImg  = '<img src="https://dyncdn2.com/static/20/img/magnet.gif"        style="height: 12px; width: 12px; margin-bottom:-2px;" border="0">';
+    const downloadImg = '<img src="https://dyncdn.me/static/20/img/16x16/download.png" style="height: 12px; width: 12px; margin-bottom:-2px;" border="0" "="">';
 
     function getStringBetween(str, begin, end) {
         if (str.indexOf(begin) >= 0) {


### PR DESCRIPTION
Resolves #4 , 

* Rating + download links are now inline with genre list,
* rating only uses 1 decimal place (no rounding logic applied, just regex matching)
* Download links are presented as images.

Suggest squash, as I realized I need to re-add `@updateUrl`